### PR TITLE
remove python yammale test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,4 @@ script:
   - yamllint _pages/*
   - ruby tests/test_filesRootDirectory.rb
   - ruby tests/test_fileEndingsPins.rb
-  - python testyamale.py
   - bundle exec jekyll build


### PR DESCRIPTION
@crichID Do you mind taking a look?

As I was walking through this course, I realized this test was failing even when the YAML was correct. We also do not have protected branches enabled. I'd like to enable protected branches, but with this test running we could slow down users' progress.

I think we should remove this test temporarily until @hectorsector is back in office to take a closer look. 