### PR TITLE
Disable empty-line warnings on yamllint

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -18,8 +18,7 @@ rules:
   document-start:
     level: error
     present: yes
-  empty-lines:
-    level: warning
+  empty-lines: disable
   hyphens:
     level: warning
   indentation:


### PR DESCRIPTION
This PR fixes https://github.com/github/training-kit/issues/496.

I tested this against ~100 commits with different levels of yamllint issues (no errors/warnings, just warnings, just errors, errors+warnings), and it seems that all it does is turn off those pesky empty-line warnings -- which is intended behavior! 

With 1 👍 I can 🚢 this.

👀 @githubschool/training-team?