### PR TITLE
Revert "Disable empty-line warnings on yamllint"

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -18,7 +18,8 @@ rules:
   document-start:
     level: error
     present: yes
-  empty-lines: disable
+  empty-lines:
+    level: warning
   hyphens:
     level: warning
   indentation:


### PR DESCRIPTION
Reverts githubschool/on-demand-github-pages#669