### PR TITLE
Add github folder to root directory tests

### DIFF
--- a/tests/test_filesRootDirectory.rb
+++ b/tests/test_filesRootDirectory.rb
@@ -5,6 +5,7 @@ class TestDirectoryContents < Test::Unit::TestCase
   def test_no_other_files_root
     correct_files = [".bundle",
      ".git",
+     ".github",
      ".gitignore",
      ".travis.yml",
      ".yamllint",


### PR DESCRIPTION
The merge of https://github.com/githubschool/on-demand-github-pages/pull/1412 adds a `.github` folder to the root directory. This PR adds that to the automated tests. 