### PR TITLE
remove samhep0803.yaml

### DIFF
--- a/_pages/samhep0803.yaml
+++ b/_pages/samhep0803.yaml
@@ -1,5 +1,0 @@
----
-githubHandle: samhep0803
-pageUrl: itstorro.github.io
-timestamp: 2017-07-10
----


### PR DESCRIPTION
What: 
- The data field pageUrl is not consistent with the file name.

Why: 
- This file should be remove to fasten future troubleshooting in Travis CI failures. 